### PR TITLE
Use path URL strategy for Flutter web to remove hash from routes

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,14 @@
 import 'package:devsite_web/presentation/app_widget.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
+import 'package:flutter_web_plugins/url_strategy.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  if (kIsWeb) {
+    setUrlStrategy(PathUrlStrategy());
+  }
+
   runApp(const AppWidget());
 }


### PR DESCRIPTION
### Motivation
- Switch Flutter web routing from hash-based URLs (`#/`) to path-based URLs so the site defaults to `https://devsite.ro/` instead of `https://devsite.ro/#/`.

### Description
- Add `import 'package:flutter_web_plugins/url_strategy.dart'` and `import 'package:flutter/foundation.dart' show kIsWeb;` and call `setUrlStrategy(PathUrlStrategy())` inside `main()` guarded by `kIsWeb` to enable clean path URLs.

### Testing
- Ran `git show --stat --oneline -1` which succeeded and shows the commit, and attempted `dart format lib/main.dart` and `flutter --version` which both failed in this environment due to missing tools.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699840899f6c832d91ae3343aaced037)