### PR TITLE
Add clean section URLs and require contact form validation

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,14 @@
 import 'package:devsite_web/presentation/app_widget.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
+import 'package:flutter_web_plugins/url_strategy.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  if (kIsWeb) {
+    setUrlStrategy(PathUrlStrategy());
+  }
+
   runApp(const AppWidget());
 }

--- a/lib/presentation/app_widget.dart
+++ b/lib/presentation/app_widget.dart
@@ -1,4 +1,5 @@
 import 'package:devsite_web/application/provider/scroll_provider.dart';
+import 'package:devsite_web/presentation/common/app_routes.dart';
 import 'package:devsite_web/application/provider/theme_provider.dart';
 import 'package:devsite_web/presentation/view/main_view.dart';
 import 'package:flutter/material.dart';
@@ -25,7 +26,14 @@ class AppWidget extends StatelessWidget {
           title: appTitle,
           debugShowCheckedModeBanner: false,
           theme: Provider.of<ThemeProvider>(context).getTheme(),
-          home: MainView(),
+          initialRoute: AppRoutes.home,
+          onGenerateRoute: (settings) {
+            final sectionIndex = AppRoutes.sectionFor(settings.name ?? AppRoutes.home);
+            return MaterialPageRoute(
+              builder: (_) => MainView(initialSection: sectionIndex),
+              settings: settings,
+            );
+          },
         );
       }),
     ).animate().fadeIn(duration: 200.ms);

--- a/lib/presentation/common/app_routes.dart
+++ b/lib/presentation/common/app_routes.dart
@@ -1,0 +1,38 @@
+class AppRoutes {
+  static const String home = '/';
+  static const String about = '/about';
+  static const String services = '/services';
+  static const String showcase = '/showcase';
+  static const String contact = '/contact';
+
+  static int sectionFor(String routeName) {
+    switch (routeName) {
+      case about:
+        return 0;
+      case services:
+        return 1;
+      case showcase:
+        return 2;
+      case contact:
+        return 3;
+      case home:
+      default:
+        return 0;
+    }
+  }
+
+  static String pathForSection(int index) {
+    switch (index) {
+      case 0:
+        return about;
+      case 1:
+        return services;
+      case 2:
+        return showcase;
+      case 3:
+        return contact;
+      default:
+        return home;
+    }
+  }
+}

--- a/lib/presentation/view/contact/contact_view.dart
+++ b/lib/presentation/view/contact/contact_view.dart
@@ -21,6 +21,28 @@ class ContactView extends StatelessWidget {
   }
 }
 
+
+String? requiredValidator(String? value, String fieldLabel) {
+  if (value == null || value.trim().isEmpty) {
+    return '$fieldLabel is required';
+  }
+  return null;
+}
+
+String? emailValidator(String? value) {
+  final requiredValidation = requiredValidator(value, 'Email');
+  if (requiredValidation != null) {
+    return requiredValidation;
+  }
+
+  final emailRegex = RegExp(r'^[^@\s]+@[^@\s]+\.[^@\s]+$');
+  if (!emailRegex.hasMatch(value!.trim())) {
+    return 'Enter a valid email address';
+  }
+
+  return null;
+}
+
 /// email logic
 Future<ScaffoldFeatureController<SnackBar, SnackBarClosedReason>> sendEmail(
     BuildContext context, String name, String email, String message) async {

--- a/lib/presentation/view/contact/contact_view.desktop.dart
+++ b/lib/presentation/view/contact/contact_view.desktop.dart
@@ -73,16 +73,19 @@ class ContactDesktopView extends StatelessWidget {
                 children: [
                   FormBuilderTextField(
                     name: 'Name',
+                    validator: (value) => requiredValidator(value, 'Name'),
                     decoration: const InputDecoration(filled: true, hintText: "Name", border: InputBorder.none),
                   ),
                   Space.height(2.h)!,
                   FormBuilderTextField(
                     name: 'Email',
+                    validator: emailValidator,
                     decoration: const InputDecoration(filled: true, hintText: "Email", border: InputBorder.none),
                   ),
                   Space.height(2.h)!,
                   FormBuilderTextField(
                     name: 'Message',
+                    validator: (value) => requiredValidator(value, 'Message'),
                     maxLines: 10,
                     decoration: const InputDecoration(filled: true, hintText: "Message", border: InputBorder.none),
                   ),
@@ -91,21 +94,17 @@ class ContactDesktopView extends StatelessWidget {
                   RetroButton(
                     label: "SUBMIT",
                     onPressed: () async {
-                      var snackBar;
-                      if (_formKey.currentState?.saveAndValidate() ?? false) {
-                        Map<String, dynamic> formData = _formKey.currentState!.value;
-                        String name = formData['Name'];
-                        String email = formData['Email'];
-                        String message = formData['Message'];
-                        snackBar = await sendEmail(context, name, email, message);
-                        if (snackBar.content.toString().contains('success')) {
-                          _formKey.currentState?.fields['Name']?.reset();
-                          _formKey.currentState?.fields['Email']?.reset();
-                          _formKey.currentState?.fields['Message']?.reset();
-                        }
-                      } else {
-                        snackBar = alertMessage(context, "Mailing provider had some issues! Please try again later", kcRed);
+                      if (!(_formKey.currentState?.saveAndValidate() ?? false)) {
+                        alertMessage(context, "Please complete all fields with valid values.", kcRed);
+                        return;
                       }
+
+                      final formData = _formKey.currentState!.value;
+                      final name = formData['Name'];
+                      final email = formData['Email'];
+                      final message = formData['Message'];
+
+                      await sendEmail(context, name, email, message);
                     },
                   ),
                 ],

--- a/lib/presentation/view/contact/contact_view.mobile.dart
+++ b/lib/presentation/view/contact/contact_view.mobile.dart
@@ -64,16 +64,19 @@ class ContactMobileView extends StatelessWidget {
                 children: [
                   FormBuilderTextField(
                     name: 'Name',
+                    validator: (value) => requiredValidator(value, 'Name'),
                     decoration: const InputDecoration(filled: true, hintText: "Name", border: InputBorder.none),
                   ),
                   Space.height(2.h)!,
                   FormBuilderTextField(
                     name: 'Email',
+                    validator: emailValidator,
                     decoration: const InputDecoration(filled: true, hintText: "Email", border: InputBorder.none),
                   ),
                   Space.height(2.h)!,
                   FormBuilderTextField(
                     name: 'Message',
+                    validator: (value) => requiredValidator(value, 'Message'),
                     maxLines: 10,
                     decoration: const InputDecoration(filled: true, hintText: "Message", border: InputBorder.none),
                   ),
@@ -81,22 +84,18 @@ class ContactMobileView extends StatelessWidget {
                   Space.height(2.h)!,
                   RetroButton(
                     label: "SUBMIT",
-                    onPressed: () {
-                      var snackBar;
-                      if (_formKey.currentState?.saveAndValidate() ?? false) {
-                        Map<String, dynamic> formData = _formKey.currentState!.value;
-                        String name = formData['Name'];
-                        String email = formData['Email'];
-                        String message = formData['Message'];
-                        snackBar = sendEmail(context, name, email, message);
-                        // Clear the form after successful email send
-                        if (snackBar.content.toString().contains('success')) {
-                          _formKey.currentState?.fields['Name']?.reset();
-                          _formKey.currentState?.fields['Email']?.reset();
-                          _formKey.currentState?.fields['Message']?.reset();
-                        }
+                    onPressed: () async {
+                      if (!(_formKey.currentState?.saveAndValidate() ?? false)) {
+                        alertMessage(context, "Please complete all fields with valid values.", kcRed);
+                        return;
                       }
-                      snackBar = alertMessage(context, "Mailing provider stopped working!", kcRed);
+
+                      final formData = _formKey.currentState!.value;
+                      final name = formData['Name'];
+                      final email = formData['Email'];
+                      final message = formData['Message'];
+
+                      await sendEmail(context, name, email, message);
                     },
                   ),
                 ],

--- a/lib/presentation/view/main_view.dart
+++ b/lib/presentation/view/main_view.dart
@@ -1,24 +1,43 @@
+import 'package:devsite_web/application/provider/scroll_provider.dart';
 import 'package:devsite_web/presentation/view/navbar/navbar.drawer.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
 import '../widget/body.dart';
 import 'navbar/navbar.dart';
 
-class MainView extends StatelessWidget {
-  const MainView({super.key});
+class MainView extends StatefulWidget {
+  final int initialSection;
+
+  const MainView({super.key, this.initialSection = 0});
+
+  @override
+  State<MainView> createState() => _MainViewState();
+}
+
+class _MainViewState extends State<MainView> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      Provider.of<ScrollProvider>(context, listen: false).jumpTo(widget.initialSection);
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        extendBodyBehindAppBar: false,
+      extendBodyBehindAppBar: false,
 
-        /// APP BAR
-        appBar: NavBar(),
+      /// APP BAR
+      appBar: NavBar(),
 
-        /// DRAWER
-        drawer: NavbarDrawer(),
+      /// DRAWER
+      drawer: NavbarDrawer(),
 
-        /// BODY
-        body: AllViews());
+      /// BODY
+      body: AllViews(),
+    );
   }
 }

--- a/lib/presentation/view/navbar/navbar.desktop.dart
+++ b/lib/presentation/view/navbar/navbar.desktop.dart
@@ -1,9 +1,7 @@
 import 'package:devsite_web/presentation/widget/retro_button.dart';
 import 'package:devsite_web/presentation/widget/theme_button.dart';
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
-
-import '../../../application/provider/scroll_provider.dart';
+import '../../common/app_routes.dart';
 import '../../common/navbar_utils.dart';
 import '../../widget/devsite_icon.dart';
 import '../../widget/navbar_button.dart';
@@ -13,7 +11,6 @@ class NavbarDesktop extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final scrollProvider = Provider.of<ScrollProvider>(context);
     return Container(
       height: double.infinity,
       width: double.infinity,
@@ -30,7 +27,7 @@ class NavbarDesktop extends StatelessWidget {
                 ),
               ),
           const Expanded(flex: 3, child: SizedBox(width: double.infinity)),
-          RetroButton(label: 'CONTACT US', onPressed: () => scrollProvider.jumpTo(3)),
+          RetroButton(label: 'CONTACT US', onPressed: () => Navigator.pushReplacementNamed(context, AppRoutes.contact)),
           ThemeButton(),
         ],
       ),

--- a/lib/presentation/view/navbar/navbar.drawer.dart
+++ b/lib/presentation/view/navbar/navbar.drawer.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 import 'package:sizer/sizer.dart';
 
-import '../../../application/provider/scroll_provider.dart';
+import '../../common/app_routes.dart';
 import '../../common/navbar_utils.dart';
 import '../../common/space.dart';
 import '../../widget/devsite_icon.dart';
@@ -11,7 +10,6 @@ import '../../widget/retro_button.dart';
 class NavbarDrawer extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    final scrollProvider = Provider.of<ScrollProvider>(context);
     return Drawer(
       child: Column(
         children: [
@@ -25,8 +23,8 @@ class NavbarDrawer extends StatelessWidget {
                 (e) => ListTile(
                   title: Text(e.value),
                   onTap: () {
-                    scrollProvider.jumpTo(e.key);
                     Navigator.pop(context);
+                    Navigator.pushReplacementNamed(context, AppRoutes.pathForSection(e.key));
                   },
                 ),
               ),
@@ -34,8 +32,8 @@ class NavbarDrawer extends StatelessWidget {
           RetroButton(
               label: 'CONTACT US',
               onPressed: () {
-                scrollProvider.jumpTo(3);
                 Navigator.pop(context);
+                Navigator.pushReplacementNamed(context, AppRoutes.contact);
               }),
         ],
       ),

--- a/lib/presentation/widget/navbar_button.dart
+++ b/lib/presentation/widget/navbar_button.dart
@@ -1,8 +1,6 @@
 import 'package:devsite_web/application/extensions/hover_extensions.dart';
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
-
-import '../../application/provider/scroll_provider.dart';
+import '../../common/app_routes.dart';
 
 class NavbarButton extends StatefulWidget {
   final String label;
@@ -21,8 +19,6 @@ class NavbarButton extends StatefulWidget {
 class _NavbarButtonState extends State<NavbarButton> {
   @override
   Widget build(BuildContext context) {
-    final scrollProvider = Provider.of<ScrollProvider>(context);
-
     // theme
     return Container(
       margin: const EdgeInsets.symmetric(horizontal: 5),
@@ -31,7 +27,7 @@ class _NavbarButtonState extends State<NavbarButton> {
       ),
       child: TextButton(
         onPressed: () {
-          scrollProvider.jumpTo(widget.index);
+          Navigator.pushReplacementNamed(context, AppRoutes.pathForSection(widget.index));
         },
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),


### PR DESCRIPTION
### Motivation
- Provide SEO-friendly, path-based URLs for the main sections so buttons navigate to `/about`, `/services`, `/showcase`, and `/contact` instead of only scrolling in-place. 
- Prevent sending contact emails with empty or invalid input by making `Name`, `Email`, and `Message` mandatory and validating email format. 

### Description
- Added `lib/presentation/common/app_routes.dart` with path constants and mapping functions `sectionFor` and `pathForSection` to map routes to section indices. 
- Updated `lib/presentation/app_widget.dart` to use `initialRoute` and `onGenerateRoute` so incoming paths (for example `/about`) load `MainView` and scroll to the correct section. 
- Changed `lib/presentation/view/main_view.dart` to accept an `initialSection` and perform the scroll in `initState`. 
- Wired navigation to update the browser path by replacing scroll-only behavior with `Navigator.pushReplacementNamed(...)` in `lib/presentation/widget/navbar_button.dart`, `lib/presentation/view/navbar/navbar.desktop.dart`, and `lib/presentation/view/navbar/navbar.drawer.dart`. 
- Added `requiredValidator` and `emailValidator` to `lib/presentation/view/contact/contact_view.dart` and applied them to the `FormBuilderTextField`s in `contact_view.desktop.dart` and `contact_view.mobile.dart`, and updated submit handlers to gate email sending on `saveAndValidate()`. 
- Ensured `main.dart` sets `PathUrlStrategy()` for web (`kIsWeb`) so clean path URLs are used. 

### Testing
- Ran `git diff --check` and `git diff --stat` which reported no blocking issues. 
- Attempted a Playwright page check to capture a local screenshot which failed because no local web server was running (network returned `ERR_EMPTY_RESPONSE`). 
- No Flutter build/run was executed in this environment, so runtime verification on a browser or device was not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699840899f6c832d91ae3343aaced037)