### PR TITLE
Sync URL path with active section during scroll

### DIFF
--- a/lib/application/provider/scroll_provider.dart
+++ b/lib/application/provider/scroll_provider.dart
@@ -6,6 +6,6 @@ class ScrollProvider extends ChangeNotifier {
   final ItemPositionsListener itemPositionsListener = ItemPositionsListener.create();
   final scrollDuration = const Duration(seconds: 2);
 
-  void jumpTo(int index) => itemScrollController.scrollTo(
+  Future<void> jumpTo(int index) => itemScrollController.scrollTo(
       index: index, duration: scrollDuration, curve: Curves.easeInOutCubic, alignment: 0);
 }

--- a/lib/application/provider/scroll_provider.dart
+++ b/lib/application/provider/scroll_provider.dart
@@ -3,6 +3,7 @@ import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 
 class ScrollProvider extends ChangeNotifier {
   final ItemScrollController itemScrollController = ItemScrollController();
+  final ItemPositionsListener itemPositionsListener = ItemPositionsListener.create();
   final scrollDuration = const Duration(seconds: 2);
 
   void jumpTo(int index) => itemScrollController.scrollTo(

--- a/lib/presentation/view/main_view.dart
+++ b/lib/presentation/view/main_view.dart
@@ -18,6 +18,7 @@ class MainView extends StatefulWidget {
 
 class _MainViewState extends State<MainView> {
   late final ScrollProvider _scrollProvider;
+  bool _isRouteDrivenScrollInProgress = false;
 
   @override
   void initState() {
@@ -25,9 +26,9 @@ class _MainViewState extends State<MainView> {
     _scrollProvider = Provider.of<ScrollProvider>(context, listen: false);
     _scrollProvider.itemPositionsListener.itemPositions.addListener(_onSectionChangedByScroll);
 
-    WidgetsBinding.instance.addPostFrameCallback((_) {
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
       if (!mounted) return;
-      _scrollProvider.jumpTo(widget.initialSection);
+      await _runRouteDrivenScroll(widget.initialSection);
     });
   }
 
@@ -37,8 +38,18 @@ class _MainViewState extends State<MainView> {
     super.dispose();
   }
 
+  Future<void> _runRouteDrivenScroll(int sectionIndex) async {
+    _isRouteDrivenScrollInProgress = true;
+
+    try {
+      await _scrollProvider.jumpTo(sectionIndex);
+    } finally {
+      _isRouteDrivenScrollInProgress = false;
+    }
+  }
+
   void _onSectionChangedByScroll() {
-    if (!mounted) return;
+    if (!mounted || _isRouteDrivenScrollInProgress) return;
 
     final visibleItems = _scrollProvider.itemPositionsListener.itemPositions.value
         .where((position) => position.itemTrailingEdge > 0)

--- a/lib/presentation/view/main_view.dart
+++ b/lib/presentation/view/main_view.dart
@@ -1,4 +1,5 @@
 import 'package:devsite_web/application/provider/scroll_provider.dart';
+import 'package:devsite_web/presentation/common/app_routes.dart';
 import 'package:devsite_web/presentation/view/navbar/navbar.drawer.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -16,13 +17,44 @@ class MainView extends StatefulWidget {
 }
 
 class _MainViewState extends State<MainView> {
+  late final ScrollProvider _scrollProvider;
+
   @override
   void initState() {
     super.initState();
+    _scrollProvider = Provider.of<ScrollProvider>(context, listen: false);
+    _scrollProvider.itemPositionsListener.itemPositions.addListener(_onSectionChangedByScroll);
+
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      Provider.of<ScrollProvider>(context, listen: false).jumpTo(widget.initialSection);
+      _scrollProvider.jumpTo(widget.initialSection);
     });
+  }
+
+  @override
+  void dispose() {
+    _scrollProvider.itemPositionsListener.itemPositions.removeListener(_onSectionChangedByScroll);
+    super.dispose();
+  }
+
+  void _onSectionChangedByScroll() {
+    if (!mounted) return;
+
+    final visibleItems = _scrollProvider.itemPositionsListener.itemPositions.value
+        .where((position) => position.itemTrailingEdge > 0)
+        .toList();
+
+    if (visibleItems.isEmpty) return;
+
+    visibleItems.sort((a, b) => a.itemLeadingEdge.compareTo(b.itemLeadingEdge));
+    final currentIndex = visibleItems.first.index;
+    final routeSection = currentIndex > 3 ? 3 : currentIndex;
+    final nextRoute = AppRoutes.pathForSection(routeSection);
+    final currentRoute = ModalRoute.of(context)?.settings.name;
+
+    if (currentRoute == nextRoute) return;
+
+    Navigator.pushReplacementNamed(context, nextRoute);
   }
 
   @override

--- a/lib/presentation/widget/body.dart
+++ b/lib/presentation/widget/body.dart
@@ -27,6 +27,7 @@ class AllViews extends StatelessWidget {
       itemCount: AllViews.views.length,
       itemBuilder: (context, index) => AllViews.views[index],
       itemScrollController: scrollProvider.itemScrollController,
+      itemPositionsListener: scrollProvider.itemPositionsListener,
     );
   }
 }


### PR DESCRIPTION
### Motivation
- Ensure the browser URL updates to the same routes (`/about`, `/services`, `/showcase`, `/contact`) when the user scrolls and a section becomes visible, matching the behavior of the navbar click handlers.

### Description
- Added `ItemPositionsListener` to `ScrollProvider` so section visibility can be observed from the scrolling list via `itemPositionsListener`.
- Wired `ScrollablePositionedList` to use `itemPositionsListener` so the app can detect which item is on screen while scrolling.
- Updated `MainView` to listen for visible-section changes, determine the current visible section, and call `Navigator.pushReplacementNamed` to update the route when the visible section changes.
- Preserved existing route→initial-section behavior via `initialSection` and added listener cleanup in `dispose` to avoid leaks.

### Testing
- Inspected the diffs of the modified files (`lib/application/provider/scroll_provider.dart`, `lib/presentation/widget/body.dart`, `lib/presentation/view/main_view.dart`) to confirm the intended changes were applied.
- Tried to run `dart format` to validate formatting but `dart` is not available in this environment (failed).
- Tried to run `flutter --version` to validate the runtime environment but `flutter` is not available in this environment (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69987c502184832dac3ed188f675f33a)